### PR TITLE
Replaces WP_Query to WC_Product_Query in Product connections

### DIFF
--- a/src/class-actions.php
+++ b/src/class-actions.php
@@ -15,6 +15,7 @@ use WPGraphQL\Extensions\WooCommerce\Type\WPEnum\Catalog_Visibility;
 use WPGraphQL\Extensions\WooCommerce\Type\WPEnum\Discount_Type;
 use WPGraphQL\Extensions\WooCommerce\Type\WPEnum\Manage_Stock;
 use WPGraphQL\Extensions\WooCommerce\Type\WPEnum\Order_Status;
+use WPGraphQL\Extensions\WooCommerce\Type\WPEnum\Product_Types;
 use WPGraphQL\Extensions\WooCommerce\Type\WPEnum\Stock_Status;
 use WPGraphQL\Extensions\WooCommerce\Type\WPEnum\Tax_Class;
 use WPGraphQL\Extensions\WooCommerce\Type\WPEnum\Tax_Status;
@@ -76,6 +77,7 @@ class Actions {
 		Discount_Type::register();
 		Manage_Stock::register();
 		Order_Status::register();
+		Product_Types::register();
 		Stock_Status::register();
 		Tax_Class::register();
 		Tax_Status::register();

--- a/src/connection/class-products.php
+++ b/src/connection/class-products.php
@@ -145,15 +145,15 @@ class Products extends WC_Connection {
 				'description' => __( 'Limit result set to products assigned a specific status.', 'wp-graphql-woocommerce' ),
 			),
 			'type'              => array(
-				'type'        => 'String',
+				'type'        => 'ProductTypesEnum',
 				'description' => __( 'Limit result set to products assigned a specific type.', 'wp-graphql-woocommerce' ),
 			),
 			'typeIn'            => array(
-				'type'        => array( 'list_of' => 'String' ),
+				'type'        => array( 'list_of' => 'ProductTypesEnum' ),
 				'description' => __( 'Limit result set to products assigned to a group of specific types.', 'wp-graphql-woocommerce' ),
 			),
 			'typeNotIn'         => array(
-				'type'        => array( 'list_of' => 'String' ),
+				'type'        => array( 'list_of' => 'ProductTypesEnum' ),
 				'description' => __( 'Limit result set to products not assigned to a group of specific types.', 'wp-graphql-woocommerce' ),
 			),
 			'sku'               => array(

--- a/src/model/class-product-variation.php
+++ b/src/model/class-product-variation.php
@@ -127,6 +127,9 @@ class Product_Variation extends Crud_CPT {
 				'regularPrice'       => function() {
 					return ! empty( $this->data->get_regular_price() ) ? $this->data->get_regular_price() : null;
 				},
+				'type'               => function() {
+					return ! empty( $this->data->get_type() ) ? $this->data->get_type() : null;
+				},
 				/**
 				 * Connection resolvers fields
 				 *

--- a/src/type/enum/class-product-type.php
+++ b/src/type/enum/class-product-type.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * WPEnum Type - ProductTypesEnum
+ *
+ * @package \WPGraphQL\Extensions\WooCommerce\Type\WPEnum
+ * @since   0.0.2
+ */
+
+namespace WPGraphQL\Extensions\WooCommerce\Type\WPEnum;
+
+use WPGraphQL\Type\WPEnumType;
+
+/**
+ * Class Product_Types
+ */
+class Product_Types {
+	/**
+	 * Registers type
+	 */
+	public static function register() {
+		$values = apply_filters(
+			'graphql_product_types_enum_values',
+			array(
+				'SIMPLE'    => array(
+					'value'       => 'simple',
+					'description' => __( 'A simple product', 'wp-graphql-woocommerce' ),
+				),
+				'GROUPED'   => array(
+					'value'       => 'grouped',
+					'description' => __( 'A product group', 'wp-graphql-woocommerce' ),
+				),
+				'EXTERNAL'  => array(
+					'value'       => 'external',
+					'description' => __( 'An external product', 'wp-graphql-woocommerce' ),
+				),
+				'VARIABLE'  => array(
+					'value'       => 'variable',
+					'description' => __( 'A variable product', 'wp-graphql-woocommerce' ),
+				),
+				'VARIATION' => array(
+					'value'       => 'variation',
+					'description' => __( 'A product variation', 'wp-graphql-woocommerce' ),
+				),
+			)
+		);
+
+		register_graphql_enum_type(
+			'ProductTypesEnum',
+			array(
+				'description' => __( 'Product type enumeration', 'wp-graphql' ),
+				'values'      => $values,
+			)
+		);
+	}
+}

--- a/src/type/object/class-product-type.php
+++ b/src/type/object/class-product-type.php
@@ -54,7 +54,7 @@ class Product_Type {
 						'description' => __( 'Date product last updated', 'wp-graphql-woocommerce' ),
 					),
 					'type'              => array(
-						'type'        => 'String',
+						'type'        => 'ProductTypesEnum',
 						'description' => __( 'Product type', 'wp-graphql-woocommerce' ),
 					),
 					'name'              => array(

--- a/src/type/object/class-product-variation-type.php
+++ b/src/type/object/class-product-variation-type.php
@@ -112,6 +112,10 @@ class Product_Variation_Type {
 						'type'        => 'String',
 						'description' => __( 'Product variation\'s sale price', 'wp-graphql-woocommerce' ),
 					),
+					'type'              => array(
+						'type'        => 'ProductTypesEnum',
+						'description' => __( 'Product type', 'wp-graphql-woocommerce' ),
+					),
 				),
 				'resolve_node'      => function( $node, $id, $type, $context ) {
 					if ( 'product_variation' === $type ) {

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -51,6 +51,7 @@ return array(
     'WPGraphQL\\Extensions\\WooCommerce\\Type\\WPEnum\\Discount_Type' => $baseDir . '/src/type/enum/class-discount-type.php',
     'WPGraphQL\\Extensions\\WooCommerce\\Type\\WPEnum\\Manage_Stock' => $baseDir . '/src/type/enum/class-manage-stock.php',
     'WPGraphQL\\Extensions\\WooCommerce\\Type\\WPEnum\\Order_Status' => $baseDir . '/src/type/enum/class-order-status.php',
+    'WPGraphQL\\Extensions\\WooCommerce\\Type\\WPEnum\\Product_Types' => $baseDir . '/src/type/enum/class-product-type.php',
     'WPGraphQL\\Extensions\\WooCommerce\\Type\\WPEnum\\Stock_Status' => $baseDir . '/src/type/enum/class-stock-status.php',
     'WPGraphQL\\Extensions\\WooCommerce\\Type\\WPEnum\\Tax_Class' => $baseDir . '/src/type/enum/class-tax-class.php',
     'WPGraphQL\\Extensions\\WooCommerce\\Type\\WPEnum\\Tax_Rate_Connection_Orderby_Enum' => $baseDir . '/src/type/enum/class-tax-rate-connection-orderby-enum.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -66,6 +66,7 @@ class ComposerStaticInit703f21dde3c5889862ac86d8135b48b6
         'WPGraphQL\\Extensions\\WooCommerce\\Type\\WPEnum\\Discount_Type' => __DIR__ . '/../..' . '/src/type/enum/class-discount-type.php',
         'WPGraphQL\\Extensions\\WooCommerce\\Type\\WPEnum\\Manage_Stock' => __DIR__ . '/../..' . '/src/type/enum/class-manage-stock.php',
         'WPGraphQL\\Extensions\\WooCommerce\\Type\\WPEnum\\Order_Status' => __DIR__ . '/../..' . '/src/type/enum/class-order-status.php',
+        'WPGraphQL\\Extensions\\WooCommerce\\Type\\WPEnum\\Product_Types' => __DIR__ . '/../..' . '/src/type/enum/class-product-type.php',
         'WPGraphQL\\Extensions\\WooCommerce\\Type\\WPEnum\\Stock_Status' => __DIR__ . '/../..' . '/src/type/enum/class-stock-status.php',
         'WPGraphQL\\Extensions\\WooCommerce\\Type\\WPEnum\\Tax_Class' => __DIR__ . '/../..' . '/src/type/enum/class-tax-class.php',
         'WPGraphQL\\Extensions\\WooCommerce\\Type\\WPEnum\\Tax_Rate_Connection_Orderby_Enum' => __DIR__ . '/../..' . '/src/type/enum/class-tax-rate-connection-orderby-enum.php',


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Uses WC_Product_Query instead of WP_Query. Adds support for custom Product data stores, however pagination functionality will to still have to filtered in order to work properly.
- [x] WP_Query => WC_Product_Query

Implements `ProductTypesEnum` for resolve product type. values are filterable through the `graphql_product_types_enum` hook.
- [x] `ProductTypesEnum` type
- [x] `Products` connections where args `type`, `typeIn`, `typeNotIn` updated
- [x] `Product` type field `type` updated
- [x] `ProductVariation` type field `type` updated

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …