### PR TITLE
Adds "*_restricted_cap" filters

### DIFF
--- a/src/model/class-crud-cpt.php
+++ b/src/model/class-crud-cpt.php
@@ -48,7 +48,10 @@ abstract class Crud_CPT extends Model {
 		$GLOBALS['post'] = $post;
 		setup_postdata( $post );
 
-		$restricted_cap = $this->get_restricted_cap();
+		$restricted_cap = apply_filters(
+			$this->post_type_object->name . '_restricted_cap',
+			$this->get_restricted_cap()
+		);
 
 		parent::__construct( $restricted_cap, $allowed_restricted_fields, $author_id );
 	}

--- a/src/model/class-customer.php
+++ b/src/model/class-customer.php
@@ -37,7 +37,9 @@ class Customer extends Model {
 			'displayName',
 		];
 
-		parent::__construct( 'list_users', $allowed_restricted_fields, $id );
+		$restricted_cap = apply_filters( 'customer_restricted_cap', 'list_users' );
+
+		parent::__construct( $restricted_cap, $allowed_restricted_fields, $id );
 	}
 
 	/**

--- a/src/model/class-order-item.php
+++ b/src/model/class-order-item.php
@@ -45,7 +45,9 @@ class Order_Item extends Model {
 			'orderItemId',
 		);
 
-		parent::__construct( '', $allowed_restricted_fields, null );
+		$restricted_cap = apply_filters( 'order_item_restricted_cap', '' );
+
+		parent::__construct( $restricted_cap, $allowed_restricted_fields, null );
 	}
 
 	/**

--- a/src/model/class-shipping-method.php
+++ b/src/model/class-shipping-method.php
@@ -35,7 +35,9 @@ class Shipping_Method extends Model {
 			'rateId',
 		);
 
-		parent::__construct( '', $allowed_restricted_fields, null );
+		$restricted_cap = apply_filters( 'shipping_method_restricted_cap', '' );
+
+		parent::__construct( $restricted_cap, $allowed_restricted_fields, null );
 	}
 
 	/**

--- a/src/model/class-tax-rate.php
+++ b/src/model/class-tax-rate.php
@@ -35,7 +35,9 @@ class Tax_Rate extends Model {
 			'rateId',
 		);
 
-		parent::__construct( '', $allowed_restricted_fields, null );
+		$restricted_cap = apply_filters( 'tax_rate_restricted_cap', '' );
+
+		parent::__construct( $restricted_cap, $allowed_restricted_fields, null );
 	}
 
 	/**


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds hooks for filtering the `restricted_cap` property used in Model classes. The naming convention goes `{post_type}_restricted_cap` for types extending `Crud_CPT` and `{node_type}_restricted_cap` for all others. For example the hook for the Customer model is named `customer_restricted_cap`.


Does this close any currently open issues?
------------------------------------------
#51 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 18.04

**WordPress Version:** 5.2